### PR TITLE
Fix xml_to_csv.py

### DIFF
--- a/xml_to_csv.py
+++ b/xml_to_csv.py
@@ -38,10 +38,10 @@ def xml_to_csv(path):
                 int(root.find("size")[0].text),
                 int(root.find("size")[1].text),
                 member[0].text,
-                int(member[4][0].text),
-                int(member[4][1].text),
-                int(member[4][2].text),
-                int(member[4][3].text),
+                int(round(float(member[4][0].text))),
+                int(round(float(member[4][1].text))),
+                int(round(float(member[4][2].text))),
+                int(round(float(member[4][3].text))),
             )
             xml_list.append(value)
     column_name = [


### PR DESCRIPTION
After resizing images for data augmentation the xml_to_csv.py crashed.
Handling float numbers fixes the error