### PR TITLE
Use names to locate the attributes instead of using the index.

### DIFF
--- a/xml_to_csv.py
+++ b/xml_to_csv.py
@@ -35,13 +35,13 @@ def xml_to_csv(path):
             classes_names.append(member[0].text)
             value = (
                 root.find("filename").text,
-                int(root.find("size")[0].text),
-                int(root.find("size")[1].text),
-                member[0].text,
-                int(member[4][0].text),
-                int(member[4][1].text),
-                int(member[4][2].text),
-                int(member[4][3].text),
+                int(root.find("size").find("width").text),
+                int(root.find("size").find("height").text),
+                member.find("name").text,
+                int(member.find("bndbox").find("xmin").text),
+                int(member.find("bndbox").find("ymin").text),
+                int(member.find("bndbox").find("xmax").text),
+                int(member.find("bndbox").find("ymax").text),
             )
             xml_list.append(value)
     column_name = [


### PR DESCRIPTION
Since the order of the XML nodes is not guaranteed, it's better to use the names to find values instead of just using the indexes. 