### PR TITLE
Updated generate tfrecords for newer tensorflow

### DIFF
--- a/generate_tfrecord.py
+++ b/generate_tfrecord.py
@@ -24,7 +24,7 @@ from PIL import Image
 from object_detection.utils import dataset_util
 from collections import namedtuple, OrderedDict
 
-flags = tf.app.flags
+flags = tf.compat.v1.flags
 flags.DEFINE_string("csv_input", "", "Path to the CSV input")
 flags.DEFINE_string("output_path", "", "Path to output TFRecord")
 flags.DEFINE_string(
@@ -50,7 +50,7 @@ def split(df, group):
 
 
 def create_tf_example(group, path, label_map):
-    with tf.gfile.GFile(os.path.join(path, "{}".format(group.filename)), "rb") as fid:
+    with tf.io.gfile.GFile(os.path.join(path, "{}".format(group.filename)), "rb") as fid:
         encoded_jpg = fid.read()
     encoded_jpg_io = io.BytesIO(encoded_jpg)
     image = Image.open(encoded_jpg_io)
@@ -104,7 +104,7 @@ def create_tf_example(group, path, label_map):
 
 
 def main(_):
-    writer = tf.python_io.TFRecordWriter(FLAGS.output_path)
+    writer = tf.io.TFRecordWriter(FLAGS.output_path)
     path = os.path.join(os.getcwd(), FLAGS.img_path)
     examples = pd.read_csv(FLAGS.csv_input)
 
@@ -131,4 +131,4 @@ def main(_):
 
 
 if __name__ == "__main__":
-    tf.app.run()
+    tf.compat.v1.app.run()


### PR DESCRIPTION
It seems that some of the modules being used from tensorflow for generating the TFrecords have been deprecated.

I've had to do these changes to the script for it to run on a colab which seems to be using TF2.0.

I would suggest commiting these to the base repo so that the tutorial still runs without the need for debugging :)